### PR TITLE
Allow to keep major or minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,18 @@ container image names.
 
 ### Flags
 
-    -exclude-beta-tags  - exclude 'beta' tags (and 'alpha', 'rc')
-    -h                  - show help
-    -json               - print JSON
-    -json-pretty        - print JSON, prettyfied
-    -limit-per-registry - n concurrent fetch operations per registry
-    -show-old           - show older tags
-    -simple-markers     - use simple ascii markers
-    -stats              - show stats
-    -strict-labels      - strict label matching
-    -timeout            - time out fetch operation after <dur>
-    -version            - show version
+    -exclude-beta-tags        - exclude 'beta' tags (and 'alpha', 'rc')
+    -h                        - show help
+    -json                     - print JSON
+    -json-pretty              - print JSON, prettyfied
+    -limit-per-registry       - n concurrent fetch operations per registry
+    -show-old                 - show older tags
+    -simple-markers           - use simple ascii markers
+    -stats                    - show stats
+    -strict-labels            - strict label matching
+    -timeout                  - time out fetch operation after <dur>
+    -keep=["major"|"minor"]   - keep major/minor version
+    -version                  - show version
 
 ## Snippets
 
@@ -40,6 +41,11 @@ If no update is available, the output would look like this:
 
     $> cciu alpine:3.13.5
     =       alpine:3.13.5
+
+To only check for updates of patch version keeping the minor version:
+
+    $> cciu -keep=minor alpine:3.11.4
+    ▲       alpine:3.11.13
 
 In addition, the output could be JSON to process it somewhere else:
 

--- a/cmd/cciu/filter.go
+++ b/cmd/cciu/filter.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"cciu/internal/tag"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 )
@@ -30,5 +33,24 @@ func (list fList) filterStrictLabels(label string, doFilter bool) fList {
 	f := func(v *semver.Version) bool {
 		return v.Prerelease() == label
 	}
+	return append(list, f)
+}
+
+func (list fList) filterVersionLevel(base *semver.Version, level string) fList {
+	var c *semver.Constraints
+
+	switch strings.ToLower(level) {
+	case "":
+		return list
+	case "major":
+		c, _ = semver.NewConstraint(fmt.Sprintf("~%d", base.Major()))
+	case "minor":
+		c, _ = semver.NewConstraint(fmt.Sprintf("~%d.%d", base.Major(), base.Minor()))
+	default:
+		fmt.Fprintf(os.Stderr, "Ignoring unknown version Level: %s\n", level)
+		return list
+	}
+	f := tag.ConstraintFilter(c)
+
 	return append(list, f)
 }

--- a/cmd/cciu/main.go
+++ b/cmd/cciu/main.go
@@ -25,8 +25,9 @@ type cciuRepoTags struct {
 
 type cciuOpts struct {
 	Filter struct {
-		IgnoreBeta   bool
-		StrictLabels bool
+		IgnoreBeta       bool
+		StrictLabels     bool
+		KeepVersionLevel string
 	}
 
 	Fetcher registry.Fetcher
@@ -40,6 +41,7 @@ func main() {
 
 	flag.BoolVar(&opts.Filter.IgnoreBeta, "exclude-beta-tags", false, "exclude 'beta' tags")
 	flag.BoolVar(&opts.Filter.StrictLabels, "strict-labels", false, "strict label matching")
+	flag.StringVar(&opts.Filter.KeepVersionLevel, "keep", "", "keep [major|minor] version")
 
 	doPrintJSON := flag.Bool("json", false, "use json output format")
 	doPrettyPrintJSON := flag.Bool("json-pretty", false, "indent json output")
@@ -176,6 +178,7 @@ func compareAndPrint(spec *imagespec.Spec, rtags map[string]*cciuRepoTags, opts 
 	fl = fl.filterHugeVersionGaps(v)
 	fl = fl.filterBetaVersions(opts.Filter.IgnoreBeta)
 	fl = fl.filterStrictLabels(spec.Label, opts.Filter.StrictLabels)
+	fl = fl.filterVersionLevel(v, opts.Filter.KeepVersionLevel)
 
 	tags := tag.NewFromStrings(rt.Tags, tag.ApplyFilterList(fl))
 	tags.Sort()

--- a/internal/tag/filter.go
+++ b/internal/tag/filter.go
@@ -28,6 +28,14 @@ func HugeVersionHeuristicFilter(a *semver.Version, n int) FilterFunc {
 	return filter
 }
 
+// ConstaintFilter generates a tag.FilterFunc based on a semver.Constraint.
+// The Check() method already has the same interface as required for FilterFunc,
+// hence, just return the function.
+func ConstraintFilter(c *semver.Constraints) FilterFunc {
+
+	return c.Check
+}
+
 // IgnoreBetaVersions filters all labels which start with
 // * "beta" - for beta-versions
 // * "alpha" - for alpha-versions


### PR DESCRIPTION
A filter is added that allows to keep the major/minor number in
order to only consider updates of the minor/patch version level.